### PR TITLE
Update Access Token Expiry to 1 Day

### DIFF
--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -29,7 +29,7 @@ export async function createSessionHandler(
 
   res.cookie("accessToken", accessToken, {
     httpOnly: true,
-    maxAge: 1000 * 60 * 15,
+    maxAge: 1000 * 60 * 60 * 24,
   });
 
   res.cookie("refreshToken", refreshToken, {

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -7,7 +7,7 @@ export function signAccessToken(user: User) {
   const payload = omit(user, user.password);
 
   const accessToken = signJwt(payload, "accessTokenPrivateKey", {
-    expiresIn: "15m",
+    expiresIn: "1d",
   });
 
   return accessToken;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Changes
This is not a great change, but currently access tokens expire every 15 minutes and I'm too lazy to write logic in the front-end to regenerate a new access token if a refresh token is available.

These changes prevent needing to re-log every 15 min, and is purely for the symposium.
<!-- Describe your changes in detail -->

## Screenshots (if appropriate)

<!--- If the PR includes UI changes, add screenshots/gifs/videos to show the result. -->

## Test Steps

<!-- Add any test steps for reviewers to follow. -->

## Related PRs (if any)

<!-- Add links to any related PRs. -->
